### PR TITLE
use config.ini for graylog info, allow setting full graylog api base …

### DIFF
--- a/LDAP/config.ini
+++ b/LDAP/config.ini
@@ -4,3 +4,8 @@ user = ldap_user
 password = YourPassword1234
 search_base = DC=yourdomain,DC=com
 ca_cert_file = ca_cert.cer
+
+[graylog]
+base_uri = https://hostname.domain.tld
+api_token = xxx
+data_adapter_oid = 68dc36fe455916a2e5e25e3e

--- a/LDAP/send_users.py
+++ b/LDAP/send_users.py
@@ -2,15 +2,24 @@ import requests
 import json
 import time
 import sys
+import configparser
+
+config = configparser.ConfigParser()
+config.read('config.ini')
 
 # --- Configuration ---
 # Replace with your Graylog cloud account domain (without http:// or https://)
-GRAYLOG_DOMAIN = "yourdomain.graylog.cloud" 
+# GRAYLOG_DOMAIN = "yourdomain.graylog.cloud"
+GRAYLOG_BASE_URI = config.get('graylog', 'base_uri')
+
 # Replace with the specific Adapter ID you are targeting
-ADAPTER_ID = "Adapter_ID"
+# ADAPTER_ID = "Adapter_ID"
+ADAPTER_ID = config.get('graylog', 'data_adapter_oid')
+
 # IMPORTANT: Replace with your actual Graylog API token.
 # Keep this token secure and do not expose it publicly.
-API_TOKEN = "Your_API_Token"
+# API_TOKEN = "Your_API_Token"
+API_TOKEN = config.get('graylog', 'api_token')
 
 
 def upload_data_to_graylog(data_payload):
@@ -27,7 +36,7 @@ def upload_data_to_graylog(data_payload):
 
     # Construct the full API endpoint URL
     # Use http:// because your domain includes port 9000, which is typically for non-HTTPS traffic.
-    url = f"http://{GRAYLOG_DOMAIN}/api/plugins/org.graylog.plugins.lookup/lookup/adapters/mongodb/{ADAPTER_ID}"
+    url = f"{GRAYLOG_BASE_URI}/api/plugins/org.graylog.plugins.lookup/lookup/adapters/mongodb/{ADAPTER_ID}"
 
     # Set the necessary headers for the request
     headers = {


### PR DESCRIPTION
…URI to account for http/https

Proposed changes. While working on testing this I realized i didn't want to save my graylog token inside the python file and modified `send_users.py` to read from the existing `config.ini`.

I also noticed that `send_users.py` was hard coded to always send to `http://` and didn't allow the configured variable to affect this. I changed the variable to allow configuring the base URI (e.g. `protocol://FWDN`), also read from `config.ini`.

Tested:
<img width="937" height="147" alt="image" src="https://github.com/user-attachments/assets/5942954e-33a6-4170-a7e2-b96222b5f31f" />

<img width="629" height="365" alt="image" src="https://github.com/user-attachments/assets/67ca5520-9eb9-40d7-8d91-144e281c62d2" />
